### PR TITLE
minor fix of ISPyBClient2 and its mockup

### DIFF
--- a/ISPyBClient2.py
+++ b/ISPyBClient2.py
@@ -351,13 +351,13 @@ class ISPyBClient2(HardwareObject):
 
         try:
             try:
-                person = self.__shipping.service.findPersonByLogin(username, os.environ["SMIS_BEAMLINE_NAME"])
+                person = self.__shipping.service.findPersonByLogin(username, self.beamline_name)
             except WebFault, e:
                 logging.getLogger("ispyb_client").warning(str(e))
                 person = {}
 
             try:
-                proposal = self.__shipping.service.findProposalByLoginAndBeamline(username, os.environ["SMIS_BEAMLINE_NAME"])
+                proposal = self.__shipping.service.findProposalByLoginAndBeamline(username, self.beamline_name)
                 if not proposal:
                     logging.getLogger("ispyb_client").warning("Error in get_proposal: No proposal has been found to  the user, returning empty proposal")
                     return empty_dict
@@ -377,7 +377,7 @@ class ISPyBClient2(HardwareObject):
                 res_sessions = self.__collection.service.\
                     findSessionsByProposalAndBeamLine(proposal_code,
                                                            proposal_number,
-                                                           os.environ["SMIS_BEAMLINE_NAME"])
+                                                           self.beamline_name)
                 sessions = []
 
                 # Handels a list of sessions

--- a/ISPyBClient2Mockup.py
+++ b/ISPyBClient2Mockup.py
@@ -20,6 +20,24 @@ class ISPyBClient2Mockup(HardwareObject):
         self.__translations = {}
         self.__disabled = False
 
+    def init(self):
+        """
+        Init method declared by HardwareObject.
+        """
+        self.authServerType = self.getProperty('authServerType') or "ldap"
+        if self.authServerType == "ldap":
+            # Initialize ldap
+            self.ldapConnection=self.getObjectByRole('ldapServer')
+            if self.ldapConnection is None:
+                logging.getLogger("HWR").debug('LDAP Server is not available')
+
+        self.loginType = self.getProperty("loginType") or "proposal"
+        self.session_hwobj = self.getObjectByRole('session')
+        self.beamline_name = self.session_hwobj.beamline_name
+
+    def login (self,loginID, psd, ldap_connection=None):
+        return self.get_proposal(loginID,"")
+
 
     def get_proposal(self, proposal_code, proposal_number):
         """


### PR DESCRIPTION
For ISPyBClient2,
get beamline_name from sessionHO instead of os environment

For  ISpyBClient2Mockup,
add init and login method to adapt to mxcube3
