### PR TITLE
a few fixes of mockups

### DIFF
--- a/DetectorMockup.py
+++ b/DetectorMockup.py
@@ -45,8 +45,11 @@ class DetectorMockup(Equipment):
         self.tolerance = self.getProperty("tolerance")
         self.temp_treshold = self.getProperty("tempThreshold") 
         self.hum_treshold = self.getProperty("humidityThreshold")
-        
-        self.detector_modes_dict = eval(self.getProperty("detectorModes"))
+
+        try:
+           self.detector_modes_dict = eval(self.getProperty("detectorModes"))
+        except:
+           pass
 
     def get_collect_name(self):
         """
@@ -86,7 +89,10 @@ class DetectorMockup(Equipment):
         """
         Descript. :
         """
-        return self.detector_modes_dict.keys()	
+        if self.detector_modes_dict is not None:
+            return self.detector_modes_dict.keys()	
+        else:
+            return [] 
 
     def has_shutterless(self):
         """

--- a/DiffractometerMockup.py
+++ b/DiffractometerMockup.py
@@ -113,6 +113,8 @@ class DiffractometerMockup(Equipment):
         self.getCentringStatus = self.get_centring_status
         self.takeSnapshots = self.take_snapshots
         self.moveMotors = self.move_motors
+        self.start3ClickCentring = self.start_3Click_centring
+        self.startAutoCentring = self.start_automatic_centring
 
     def init(self):
         """
@@ -149,6 +151,7 @@ class DiffractometerMockup(Equipment):
         self.sampleXMotor = self.getDeviceByRole('sampx')
         self.sampleYMotor = self.getDeviceByRole('sampy')
         self.camera_hwobj = self.getDeviceByRole('camera')
+        self.beam_info_hwobj = self.getObjectByRole('beam_info')
 
         if self.phiMotor is not None:
             self.connect(self.phiMotor, 'stateChanged', self.phiMotorStateChanged)
@@ -170,8 +173,6 @@ class DiffractometerMockup(Equipment):
         else:
             logging.getLogger("HWR").error('MiniDiff: Sampx motor is not defined')
 
-        self.beam_info_hwobj = HardwareRepository.HardwareRepository().\
-                                getHardwareObject(self.getProperty("beam_info"))
         if self.beam_info_hwobj is not None:
             self.connect(self.beam_info_hwobj, 'beamPosChanged', self.beam_position_changed)
         else:
@@ -198,11 +199,11 @@ class DiffractometerMockup(Equipment):
 	self._drawing = drawing
 
     def use_sample_changer(self):
-        return False
+        return True
 
     def in_plate_mode(self):
-        #TODO head detection should be used to detect if in plate mode 
-	return True
+        #currently not used for mockup version
+	return False
 
     def toggle_fast_shutter(self):
         self.fast_shutter_is_open = not self.fast_shutter_is_open
@@ -265,6 +266,7 @@ class DiffractometerMockup(Equipment):
         """
         Descript. :
         """
+
         self.user_clicked_event = AsyncResult()
         x, y = self.user_clicked_event.get()
         last_centred_position[0] = x
@@ -436,6 +438,9 @@ class DiffractometerMockup(Equipment):
         """
         Descript. :
         """
+        self.emit_progress_message("Auto centring")
+        self.emit_centring_started(DiffractometerMockup.C3D_MODE)
+        self.emit('centringSuccessful')
         return
 
     def motor_positions_to_screen(self, centred_positions_dict):

--- a/DiffractometerMockup.py
+++ b/DiffractometerMockup.py
@@ -10,7 +10,7 @@ import gevent
 import random
 from gevent.event import AsyncResult
 
-import queue_model_objects_v1 as qmo
+import queue_model_objects_v1 as queue_model_objects
 
 from HardwareRepository import HardwareRepository
 from HardwareRepository.TaskUtils import *
@@ -55,21 +55,20 @@ class DiffractometerMockup(Equipment):
     C3D_MODE = "Computer automatic"
     MOVE_TO_BEAM_MODE = "Move to Beam"
 
+    MINIKAPPA = "MiniKappa"
+    PLATE = "Plate"
+    SC = "SC"
+
     def __init__(self, *args):
         """
         Descript. :
         """
         Equipment.__init__(self, *args)
 
-        qmo.CentredPosition.set_diffractometer_motor_names("phi",
-                                                           "focus",
-                                                           "phiz",
-                                                           "phiy",
-                                                           "zoom",
-                                                           "sampx",
-                                                           "sampy",
-                                                           "kappa",
-                                                           "kappa_phi")
+        queue_model_objects.CentredPosition.set_diffractometer_motor_names(\
+                "phi", "focus", "phiz", "phiy", "zoom",
+                "sampx", "sampy", "kappa", "kappa_phi")
+
 
         self.phiMotor = None
         self.phizMotor = None
@@ -78,9 +77,7 @@ class DiffractometerMockup(Equipment):
         self.zoomMotor = None
         self.sampleXMotor = None
         self.sampleYMotor = None
-        self.kappaMotor = None
-        self.kappaPhiMotor = None
-        self.camera = None
+        self.camera_hwobj = None
         self.beam_info_hwobj = None
 
         self.beam_position = None
@@ -95,22 +92,27 @@ class DiffractometerMockup(Equipment):
         self.current_centring_procedure = None
         self.current_centring_method = None
         self.current_positions_dict = None
+        self.current_phase = None
         self.centring_methods = None
         self.centring_status = None
         self.centring_time = None
         self.user_confirms_centring = None
         self.user_clicked_event = None
+        self.phase_list = None
+        self.head_type = None
+        self._drawing = None
 
         self.connect(self, 'equipmentReady', self.equipmentReady)
         self.connect(self, 'equipmentNotReady', self.equipmentNotReady)
 
-        self.startCentringMethod = self.start_centring_method 
+        self.startCentringMethod = self.start_centring_method
         self.cancelCentringMethod = self.cancel_centring_method
         self.imageClicked = self.image_clicked
         self.acceptCentring = self.accept_centring
         self.rejectCentring = self.reject_centring
         self.getCentringStatus = self.get_centring_status
         self.takeSnapshots = self.take_snapshots
+        self.moveMotors = self.move_motors
 
     def init(self):
         """
@@ -134,24 +136,39 @@ class DiffractometerMockup(Equipment):
         self.centring_status = {"valid": False}
         self.centring_time = 0
         self.user_confirms_centring = True
+        self.fast_shutter_is_open = False
         self.user_clicked_event = AsyncResult()
+
         self.image_width = 400
         self.image_height = 400
+
         self.equipmentReady()
         self.user_clicked_event = AsyncResult()
 
-        self.kappaMotor = self.getDeviceByRole('kappa')
-        self.kappaPhiMotor = self.getDeviceByRole('kappa_phi')
+        self.phiMotor = self.getDeviceByRole('phi')
+        self.sampleXMotor = self.getDeviceByRole('sampx')
+        self.sampleYMotor = self.getDeviceByRole('sampy')
+        self.camera_hwobj = self.getDeviceByRole('camera')
 
-        if self.kappaMotor is not None:
-            self.connect(self.kappaMotor, "positionChanged", self.kappa_motor_moved)
+        if self.phiMotor is not None:
+            self.connect(self.phiMotor, 'stateChanged', self.phiMotorStateChanged)
+            self.connect(self.phiMotor, "positionChanged", self.phi_motor_position_changed)
         else:
-            logging.getLogger("HWR").error('MiniDiff: kappa motor is not defined')
+            logging.getLogger("HWR").error('MiniDiff: phi motor is not defined in minidiff equipment %s', str(self.name()))
 
-        if self.kappaPhiMotor is not None:
-            self.connect(self.kappaPhiMotor, 'positionChanged', self.kappa_phi_motor_moved)
+        if self.sampleXMotor is not None:
+            self.connect(self.sampleXMotor, 'stateChanged', self.sampleX_motor_state_changed)
+            self.connect(self.sampleXMotor, 'positionChanged', self.sampleX_motor_moved)
+            self.connect(self.sampleXMotor, "positionChanged", self.emit_diffractometer_moved)
         else:
-            logging.getLogger("HWR").error('MiniDiff: kappa phi motor is not defined')
+            logging.getLogger("HWR").error('MiniDiff: Sampx motor is not defined')
+
+        if self.sampleYMotor is not None:
+            self.connect(self.sampleYMotor, 'stateChanged', self.sampleY_motor_state_changed)
+            self.connect(self.sampleYMotor, 'positionChanged', self.sampleY_motor_moved)
+            self.connect(self.sampleYMotor, "positionChanged", self.emit_diffractometer_moved)
+        else:
+            logging.getLogger("HWR").error('MiniDiff: Sampx motor is not defined')
 
         self.beam_info_hwobj = HardwareRepository.HardwareRepository().\
                                 getHardwareObject(self.getProperty("beam_info"))
@@ -160,23 +177,83 @@ class DiffractometerMockup(Equipment):
         else:
             logging.getLogger("HWR").debug('Minidiff: Beaminfo is not defined')
 
+        takeSnapshots = self.take_snapshots
+        self.getCentringStatus = self.get_centring_status
+
+        self.reversing_rotation = self.getProperty("reversingRotation")
         try:
-            self.zoom_centre = eval(self.getProperty("zoomCentre"))
+            self.grid_direction = eval(self.getProperty("gridDirection"))
         except:
-            if self.image_width is not None and self.image_height is not None:
-                self.zoom_centre = {'x': self.image_width / 2,'y' : self.image_height / 2}
-                self.beam_position = [self.image_width / 2, self.image_height / 2]
-                logging.getLogger("HWR").warning('MiniDiff: Zoom center is ' +\
-                       'not defined continuing with the middle: %s' % self.zoom_centre)
-            else:
-                logging.getLogger("HWR").warning('MiniDiff: Neither zoom centre nor camera size iz defined')
+            self.grid_direction = {"fast": (0, 1), "slow": (1, 0)}
+            logging.getLogger("HWR").warning('MiniDiff: Grid direction is not defined. Using default.')
 
         try:
-            self.omega_reference_par = eval(self.getProperty("omegaReference"))
-            self.omega_reference_motor = self.getDeviceByRole(self.omega_reference_par["motor_name"])
-            self.connect(self.omega_reference_motor, 'positionChanged', self.omega_reference_motor_moved)
+            self.current_phase = "Transfer"
+            self.phase_list = eval(self.getProperty("phaseList"))
+            self.head_type = self.getProperty("headType")
         except:
-            logging.getLogger("HWR").warning('MiniDiff: Omega axis is not defined')
+            self.phase_list = []
+
+    def set_drawing(self, drawing):
+	self._drawing = drawing
+
+    def use_sample_changer(self):
+        return False
+
+    def in_plate_mode(self):
+        #TODO head detection should be used to detect if in plate mode 
+	return True
+
+    def toggle_fast_shutter(self):
+        self.fast_shutter_is_open = not self.fast_shutter_is_open
+        self.emit('minidiffShutterStateChanged', (self.fast_shutter_is_open, ))
+
+    def get_head_type(self):
+        return self.head_type
+         
+    def get_grid_direction(self):
+        return self.grid_direction
+
+    def is_reversing_rotation(self):
+        return self.reversing_rotation == True
+
+    def phiMotorStateChanged(self,state):
+        self.emit('phiMotorStateChanged', (state, ))
+        self.emit('minidiffStateChanged', (state,))
+
+    def phi_motor_position_changed(self, position):
+        self.current_positions_dict["phi"] = position
+        self.emit('minidiffStateChanged', ("ready",)) 
+
+    def sampleX_motor_state_changed(self, state):
+        """
+        Descript. :
+        """
+        self.emit('sampxMotorStateChanged', (state, ))
+        self.emit('minidiffStateChanged', (state, ))
+
+    def sampleY_motor_state_changed(self, state):
+        """
+        Descript. :
+        """
+        self.emit('sampyMotorStateChanged', (state, ))
+        self.emit('minidiffStateChanged', (state, ))
+
+    def sampleX_motor_moved(self, pos):
+        """
+        Descript. :
+        """
+        self.current_positions_dict["sampx"] = pos
+        if time.time() - self.centring_time > 1.0:
+            self.invalidate_centring()
+
+    def sampleY_motor_moved(self, pos):
+        """
+        Descript. :
+        """
+        self.current_positions_dict["sampy"] = pos
+        if time.time() - self.centring_time > 1.0:
+            self.invalidate_centring()
 
     def getStatus(self):
         """
@@ -193,11 +270,10 @@ class DiffractometerMockup(Equipment):
         last_centred_position[0] = x
         last_centred_position[1] = y
         random_num = random.random()
-        centred_pos_dir = {'phiy': random_num * 10, 'phiz': random_num, 
-                           'sampx': 0.0, 'sampy': 9.3, 'zoom': 8.53,
-                           'phi': 311.1, 'focus': -0.42, 
-                           'kappa': self.kappaMotor.getPosition(), 
-                           'kappa_phi': self.kappaPhiMotor.getPosition()}
+        centred_pos_dir = {'phiy': random_num, 'phiz': random_num * 2, 
+                           'sampx': random_num * 3, 'sampy': random_num * 4, 
+                           'zoom': 8.53, 'phi': 311.1, 'focus': -0.42, 
+                           'kappa': 0.0, 'kappa_phi': 0.0}
         return centred_pos_dir 		
 
     def set_sample_info(self, sample_info):
@@ -244,20 +320,6 @@ class DiffractometerMockup(Equipment):
             self.centring_status = {"valid":False}
             self.emitProgressMessage("")
             self.emit('centringInvalid', ())
-
-    def kappa_motor_moved(self, pos):
-        """
-        Descript. :
-        """
-        self.emit_diffractometer_moved()
-        self.emit('kappaMoved', pos)
-
-    def kappa_phi_motor_moved(self, pos):
-        """
-        Descript. :
-        """
-        self.emit_diffractometer_moved()
-        self.emit('kappaPhiMoved', pos)
 
     def get_available_centring_methods(self):
         """
@@ -397,7 +459,23 @@ class DiffractometerMockup(Equipment):
         """
         Descript. :
         """
-        time.sleep(1)
+        if self.current_phase != "BeamLocation":
+            time.sleep(1)
+        else:
+            logging.getLogger("HWR").debug("Move to centred position disabled in BeamLocation phase.") 
+
+
+    def get_point_between_two_points(self, point_one, point_two, frame_num, frame_total):
+        new_point = {}
+        point_one = point_one.as_dict()
+        point_two = point_two.as_dict()
+        for motor in point_one.keys():
+            new_motor_pos = frame_num / float(frame_total) * abs(point_one[motor] - \
+                  point_two[motor]) + point_one[motor]
+            new_motor_pos += 0.5 * (point_two[motor] - point_one[motor]) / \
+                  frame_total
+            new_point[motor] = new_motor_pos
+        return new_point            
    
     def moveToCentredPosition(self, centred_position, wait = False):
         """
@@ -470,11 +548,10 @@ class DiffractometerMockup(Equipment):
             curr_time = time.strftime("%Y-%m-%d %H:%M:%S")
             self.centring_status["endTime"] = curr_time
             random_num = random.random()
-            motors = {'phiy': random_num * 10,  'phiz': random_num * 20,
-                      'sampx': 0.0, 'sampy': 9.3, 'zoom': 8.53, 
-                      'phi': 311.1, 'focus': -0.42, 
-                      'kappa': self.kappaMotor.getPosition(),
-                      'kappa_phi': self.kappaPhiMotor.getPosition()}
+            motors = {'phiy': random_num,  'phiz': random_num * 2,
+                      'sampx': random_num * 3, 'sampy': random_num * 4, 
+                      'zoom': random_num * 5, 'phi': random_num * 6, 
+		      'focus': -0.42, 'kappa': 0.0009, ' kappa_phi': 311.0}
 
             motors["beam_x"] = 0.1
             motors["beam_y"] = 0.1
@@ -494,7 +571,7 @@ class DiffractometerMockup(Equipment):
         """
         Descript. :
         """
-        self.emit('progressMessage', (msg,))
+        self.emit('progressMessage', msg)
 
     def get_centring_status(self):
         """
@@ -507,11 +584,10 @@ class DiffractometerMockup(Equipment):
         Descript. :
         """
         random_num = random.random()
-        return {"phi": random_num * 10, "focus": random_num * 20, 
-                "phiy" : -1.07, "phiz": -0.22, "sampx": 0.0, 
-                "sampy": 9.3, "zoom": 8.53,
-                "kappa": self.kappaMotor.getPosition(),
-                "kappa_phi": self.kappaPhiMotor.getPosition()}
+        return {"phi": random_num, "focus": random_num * 2, 
+                "phiy" : random_num * 3, "phiz": random_num * 4, 
+                "sampx": random_num * 5, "sampy": random_num * 6,
+		"kappa": 0.0009, "kappa_phi": 311.0, "zoom": 8.53}
 
     def simulateAutoCentring(self, sample_info = None):
         """
@@ -525,21 +601,29 @@ class DiffractometerMockup(Equipment):
         """
         return
 
+    def get_current_phase(self):
+        """
+        Descript. :
+        """
+        return self.current_phase
+
     def start_set_phase(self, name):
         """
         Descript. :
         """
-        return
+        self.current_phase = name
+        self.emit('minidiffPhaseChanged', (self.current_phase, ))
 
     def refresh_video(self):
         """
         Descript. :
         """
+        print "refresh"
         if self.beam_info_hwobj: 
             self.beam_info_hwobj.beam_pos_hor_changed(300) 
             self.beam_info_hwobj.beam_pos_ver_changed(200)
-        self.emit("phiMoved", 10.2)
-        self.emit("kappaMoved", 11.2)
+        self.emit("phiMotorMoved", 10.2)
+        self.emit("kappaMotorMoved", 11.2)
 
     def start_auto_focus(self): 
         """
@@ -547,13 +631,20 @@ class DiffractometerMockup(Equipment):
         """
         return 
   
-    def move_to_coord(self, x, y):
+    def move_to_coord(self, x, y, omega=None):
         """
         Descript. :
         """
+        print "moving to coord: %d %d" %(x ,y) 
+        if self.current_phase != "BeamLocation":
+            time.sleep(1)
+        else:
+            logging.getLogger("HWR").debug("Move to screen position disabled in BeamLocation phase.")
+
+    def move_motors(self, motors_dict):
         return
-     
-    def start_2D_centring(self):
+  
+    def start_2D_centring(self, coord_x=None, coord_y=None, omega=None):
         """
         Descript. :
         """
@@ -605,7 +696,7 @@ class DiffractometerMockup(Equipment):
         try:
             self.centring_status["images"] = snapshots_procedure.get()
         except:
-            logging.getLogger("HWR").exception("EMBLMiniDiff: could not take crystal snapshots")
+            logging.getLogger("HWR").exception("MiniDiff: could not take crystal snapshots")
             self.emit('centringSnapshots', (False,))
             self.emit_progress_message("")
         else:
@@ -613,13 +704,43 @@ class DiffractometerMockup(Equipment):
             self.emit_progress_message("")
         self.emit_progress_message("Sample is centred!")
 
-    def move_kappa_phi(self, kappa, kappa_phi, wait = False):
+    def stop_kappa_phi_move(self):
+        return
+
+    def move_kappa_and_phi(self, kappa_value, phi_value):
+        return
+
+    def get_centred_point_from_coord(self, x, y, return_by_names=None):
         """
         Descript. :
         """
-        if self.kappaMotor is not None:
-            self.kappaMotor.move(kappa)
-        if self.kappaPhiMotor is not None:
-            self.kappaPhiMotor.move(kappa_phi)
-    def moveMotors(self, roles_positions_dict):
-        return  
+        random_num = random.random()
+        pos = {'phiy': random_num * 10,  'phiz': random_num * 20,
+               'sampx': 0.0, 'sampy': 9.3, 'zoom': 8.53, 'phi': 311.1,
+               'focus': -0.42, 'kappa': 0.0009, ' kappa_phi': 311.0}
+        if return_by_names:
+            pos = self.convert_from_obj_to_name(pos)
+        return pos
+
+    def convert_from_obj_to_name(self, motor_pos):
+        motors = {}
+        for motor_role in ('phiy', 'phiz', 'sampx', 'sampy', 'zoom',
+                           'phi', 'focus', 'kappa', 'kappa_phi'):
+            try:
+               motors[motor_role] = motor_pos[None]
+            except KeyError:
+               motors[motor_role] = 10
+        motors["beam_x"] = 10
+        motors["beam_y"] = 10
+        return motors 
+
+    def get_last_video_frame(self):
+        if self.camera_hwobj is not None:
+            return self.camera_hwobj.get_last_frame()
+
+    def update_values(self):
+        pass
+
+    def get_phase_list(self):
+        return self.phase_list 
+ 

--- a/EnergyMockup.py
+++ b/EnergyMockup.py
@@ -1,45 +1,47 @@
-import sys
-import time
-import logging
-import math
 from HardwareRepository.BaseHardwareObjects import Equipment
-from HardwareRepository.TaskUtils import *
 
 class EnergyMockup(Equipment):
-
-class EnergyScan(Equipment):
    def init(self):
-       self.ready_event = gevent.event.Event()
        self.energy_motor = None
-       self.tunable = False
+       self.tunable = True
        self.moving = None
-       self.default_en = 0
+       self.default_en = 12
        self.en_lims = []
+       self.energy_value = 12
+       self.wavelength_value = 12.3984/self.energy_value
 
-    def canMoveEnergy(self):
-        return self.tunable
+       self.canMoveEnergy = self.can_move_energy
+       self.move_energy = self.start_move_energy 
+       self.getEnergyLimits  = self.get_energy_limits
 
-    def isConnected(self):
-        return True
+   def update_values(self):
+       self.emit("energyChanged", self.energy_value, self.wavelength_value)
 
-    def getCurrentEnergy(self):
-        return self.default_en
+   def can_move_energy(self):
+       return self.tunable
+
+   def isConnected(self):
+       return True
+
+   def getCurrentEnergy(self):
+       return self.energy_value
 
    def getCurrentWavelength(self):
-        current_en = self.getCurrentEnergy()
-        if current_en is not None:
-            return (12.3984/current_en)
-        return None
+       current_en = self.getCurrentEnergy()
+       if current_en is not None:
+           return (12.3984/current_en)
+       return None
 
-   def getEnergyLimits(self):
-        return None
+   def get_energy_limits(self):
+       return None
 
    def getWavelengthLimits(self):
-        lims = None
-        self.en_lims = self.getEnergyLimits()
-        if self.en_lims is not None:
-            lims=(12.3984/self.en_lims[1], 12.3984/self.en_lims[0])
-        return lims
+       lims = None
+       self.en_lims = self.getEnergyLimits()
+       if self.en_lims is not None:
+           lims=(12.3984/self.en_lims[1], 12.3984/self.en_lims[0])
+       return lims
 
-  def startMoveEnergy(self, value, wait=True):
-      return
+   def start_move_energy(self, value, wait=True):
+       self.energy_value = value
+       self.update_values()

--- a/ISPyBClient2Mockup.py
+++ b/ISPyBClient2Mockup.py
@@ -36,11 +36,20 @@ class ISPyBClient2Mockup(HardwareObject):
         self.beamline_name = self.session_hwobj.beamline_name
 
     def login (self,loginID, psd, ldap_connection=None):
-        return self.get_proposal(loginID,"")
 
-
-    def login(self, *args):
-        return self.get_proposal(*args)
+        # to simulate wrong loginID
+        if loginID == "wrong":
+	    return {'status':{ "code": "error", "msg": "loginID 'wrong' does not exist!" }, 'Proposal': None, 'Session': None} 
+        # to simulate wrong psd
+        if psd == "wrong":
+	    return {'status':{ "code": "error", "msg": "Wrong password!" }, 'Proposal': None, 'Session': None}
+ 
+        prop=self.get_proposal(loginID,"")
+	return {'status':{ "code": "ok", "msg": "Successful login" }, 'Proposal': prop['Proposal'],
+                 'session': prop['Session'],
+                 'local_contact': "BL Scientist",
+                 'person': prop['Person'],
+                 'laboratory': prop['Laboratory']}
 
     def get_proposal(self, proposal_code, proposal_number):
         """
@@ -68,14 +77,14 @@ class ISPyBClient2Mockup(HardwareObject):
                              'number': '000',
                              'proposalId': 1,
                              'type': 'MX'},
-                'Session': [{'scheduled': 0,
+                'Session': {'scheduled': 0,
                              'startDate': '2013-06-11 00:00:00',
                              'endDate': '2013-06-12 07:59:59',
                              'beamlineName': 'ID:TEST',
                              'timeStamp': datetime.datetime(2013, 6, 11, 9, 40, 36),
                              'comments': 'Session created by the BCM',
                              'sessionId': 34591,
-                             'proposalId': 1, 'nbShifts': 3}],
+                             'proposalId': 1, 'nbShifts': 3},
                 'Laboratory': {'laboratoryId': 1,
                                'name': 'TEST eh1'}}
 

--- a/MultiCollectMockup.py
+++ b/MultiCollectMockup.py
@@ -38,6 +38,28 @@ class MultiCollectMockup(AbstractMultiCollect, HardwareObject):
         self.emit("collectReady", (True, ))
 
     @task
+    def loop(self, owner, data_collect_parameters_list):
+        failed_msg = "Data collection failed!"
+        failed = True
+        collections_analyse_params = []
+        self.emit("collectReady", (False, ))
+        self.emit("collectStarted", (owner, 1))
+        
+        for data_collect_parameters in data_collect_parameters_list:
+            logging.debug("collect parameters = %r", data_collect_parameters)
+            failed = False
+       	    data_collect_parameters["status"]='Data collection successful'
+	    osc_id, sample_id, sample_code, sample_location = self.update_oscillations_history(data_collect_parameters)
+            self.emit('collectOscillationStarted', (owner, sample_id, sample_code, sample_location, data_collect_parameters, osc_id))
+            data_collect_parameters["status"]='Running'
+	    data_collect_parameters["status"]='Data collection successful'
+            self.emit("collectOscillationFinished", (owner, True, data_collect_parameters["status"], "12345", osc_id, data_collect_parameters))
+
+	self.emit("collectEnded", owner, not failed, failed_msg if failed else "Data collection successful")
+	logging.getLogger('HWR').info("data collection successful in loop")
+        self.emit("collectReady", (True, ))
+
+    @task
     def take_crystal_snapshots(self, number_of_snapshots):
         self.bl_control.diffractometer.takeSnapshots(number_of_snapshots, wait=True)
 

--- a/SampleChangerMockup.py
+++ b/SampleChangerMockup.py
@@ -37,6 +37,9 @@ class SampleChangerMockup(SC3.SC3):
 
         pass
 
+    def hasLoadedSample(self):
+        return True
+
     def load_sample(self, holder_length, sample_location, wait):
         return
 

--- a/ShapeHistoryMockup.py
+++ b/ShapeHistoryMockup.py
@@ -1,0 +1,386 @@
+"""
+Contains the classes
+
+* ShapeHistory
+* Shape
+* Point
+* Line
+* CanvasGrid
+
+ShapeHistory keeps track of the current shapes the user has created. The
+shapes handled are any that inherits the Shape base class. There are currently
+two shapes implemented Point and Line.
+
+Point is the graphical representation of a centred position. A point can be
+stored and managed by the ShapeHistory. the Line object represents a line
+between two Point objects.
+
+"""
+
+import logging
+import os
+import traceback
+import queue_model_objects_v1 as queue_model_objects
+import types
+
+from HardwareRepository.BaseHardwareObjects import HardwareObject
+
+SELECTED_COLOR = "green"
+NORMAL_COLOR = "yellow"
+
+
+class ShapeHistoryMockup(HardwareObject):
+    """
+    Keeps track of the current shapes the user has created. The
+    shapes handled are any that inherits the Shape base class.
+    """
+    def __init__(self, name):
+        HardwareObject.__init__(self, name)
+        self._drawing = None
+        self.shapes = {}
+        self.selected_shapes = {}
+        self.point_index = 0
+
+    def set_drawing(self, drawing):
+        """
+        Sets the drawing the Shape objects that are managed are drawn on.
+
+        :param drawing: The drawing that the shapes are drawn on.
+        :type drawing: QubDrawing (used by Qub)
+
+        :returns: None
+        """
+        if self._drawing:
+            logging.getLogger('HWR').info('Setting previous drawing:' + \
+                                          str(self._drawing) + ' to ' + \
+                                          str(drawing))
+
+        self._drawing = drawing
+
+    def get_drawing(self):
+        """
+        :returns: Returns the drawing of the shapes.
+        :rtype: QubDrawing
+        """
+        return self._drawing
+
+
+    def get_snapshot(self, qub_objects):
+        """
+        Get a snapshot of the video stream and overlay the objects
+        in qub_objects.
+
+        :param qub_objects: The QCanvas object to add on top of the video.
+        :type qub_objects: QCanvas
+
+        :returns: The snapshot
+        :rtype: QImage
+        """
+	cwd = os.getcwd()
+        path = os.path.join(cwd, "./test/HardwareObjectsMockup.xml/")
+	qimg_path = os.path.join(path, "mxcube_sample_snapshot.jpeg")
+        qimg = open (qimg_path,'rb').read()
+
+        return qimg
+
+    def get_qimage(self, image, canvas,  zoom = 1):
+        """
+        Gets the QImage from a parent widget.
+
+        :param image: The QWidget that contains the image to extract
+        :type image: QWidget
+
+        :param canvas: The QCanvas obejct to add as overlay
+        :type canvas: QCanvas
+
+        :param zoom: Zoom level
+        :type zoom: int.
+
+        :returns: The QImage contained in the parent widget.
+        :rtype: QImage
+        """
+        cwd = os.getcwd()
+        path = os.path.join(cwd, "./test/HardwareObjectsMockup.xml/")
+        img_path = os.path.join(path, "mxcube_sample_snapshot.jpeg")
+        img = open (qimg_path,'rb').read()
+
+        return img
+
+    def get_shapes(self):
+        """
+        :returns: All the shapes currently handled.
+        """
+        return self.shapes.values()
+
+    def get_points(self):
+        """
+        :returns: All points currently handled
+        """
+        current_points = []
+
+        for shape in self.get_shapes():
+            if isinstance(shape, Point):
+                current_points.append(shape)
+
+        return current_points
+        
+    def add_shape(self, shape):
+        """
+        Adds the shape <shape> to the list of handled objects.
+
+        :param shape: Shape to add.
+        :type shape: Shape object.
+
+        """
+        self.shapes[shape] = shape
+        if isinstance(shape, Point):
+            shape.set_index(self.get_available_point_index())
+
+        self.get_drawing_event_handler().de_select_all()
+        self.get_drawing_event_handler().set_selected(shape, True, call_cb = True)
+
+    def get_available_point_index(self):
+        self.point_index += 1
+        return self.point_index
+
+    def _delete_shape(self, shape):
+        shape.unhighlight()
+
+        if shape in self.selected_shapes:
+            del self.selected_shapes[shape]
+
+            if callable(self._drawing_event.selection_cb):
+                self._drawing_event.selection_cb(self.selected_shapes.values())
+
+        if shape is self._drawing_event.current_shape:
+            self._drawing_event.current_shape = None
+
+        if callable(self._drawing_event.deletion_cb):
+            self._drawing_event.deletion_cb(shape)
+
+    def delete_shape(self, shape):
+        """
+        Removes the shape <shape> from the list of handled shapes.
+
+        :param shape: The shape to remove
+        :type shape: Shape object.
+        """
+        related_points = []
+
+        #If a point remove related line first
+        if isinstance(shape, Point):
+            for s in self.get_shapes():
+                if isinstance(s, Line):
+                    for s_qub_obj in s.get_qub_objects():
+                        if  s_qub_obj in shape.get_qub_objects():
+                            self._delete_shape(s)
+                            related_points.append(s)
+                            break
+
+        self._delete_shape(shape)
+        del self.shapes[shape]
+
+        # Delete the related shapes after self._delete_shapes so that
+        # related object still exists when calling delete call back.
+        for point in related_points:
+            del self.shapes[point]
+
+    def move_shape(self, shape, new_positions):
+        """
+        Moves the shape <shape> to the position <new_position>
+
+        :param shape: The shape to move
+        :type shape: Shape
+
+        :param new_position: A tuple (X, Y)
+        :type new_position: <int, int>
+        """
+        self.shapes[shape].move(new_positions)
+
+    def clear_all(self):
+        """
+        Clear the shape history, remove all contents.
+        """
+	return
+
+    def de_select_all(self):
+        return
+
+    def select_shape_with_cpos(self, cpos):
+	return
+
+
+
+class Shape(object):
+    """
+    Base class for shapes.
+    """
+    def __init__(self):
+        object.__init__(self)
+        self._drawing = None
+
+    def get_drawing(self):
+        """
+        :returns: The drawing on which the shape is drawn.
+        :rtype: QDrawing
+        """
+        return self._drawing
+
+    def draw(self):
+        """
+        Draws the shape on its drawing.
+        """
+        pass
+
+    def get_centred_positions(self):
+        """
+        :returns: The centred position(s) associated with the shape.
+        :rtype: List of CentredPosition objects.
+        """
+        pass
+
+    def hide(self):
+        """
+        Hides the shape.
+        """
+        pass
+
+    def show(self):
+        """
+        Shows the shape.
+        """
+        pass
+
+    def update_position(self):
+        pass
+
+    def move(self, new_positions):
+        """
+        Moves the shape to the position <new_position>
+        """
+        pass
+
+    def highlight(self):
+        """
+        Highlights the shape
+        """
+        pass
+
+    def unhighlight(self):
+        """
+        Removes highlighting.
+        """
+        pass
+
+    def get_hit(self, x, y):
+        """
+        :returns: True if the shape was hit by the mouse.
+        """
+        pass
+
+    def get_qub_objects(self):
+        """
+        :returns: A list of qub objects.
+        """
+        pass
+
+
+class Line(Shape):    
+    def __init__(self, drawing, start_qub_p, end_qub_p, 
+                 start_cpos, end_cpos):
+        object.__init__(self)
+
+        self._drawing = drawing
+        self.start_qub_p = start_qub_p
+        self.end_qub_p = end_qub_p
+        self.start_cpos = start_cpos
+        self.end_cpos = end_cpos
+        self.qub_line = None
+
+
+    def get_centred_positions(self):
+        return [self.start_cpos, self.end_cpos]
+
+    def hide(self):
+        self.qub_line.hide()
+
+    def show(self):
+        self.qub_line.show()
+
+    def update_position(self):
+        self.qub_line.moveFirstPoint(self.start_qub_p._x, self.start_qub_p._y)
+        self.qub_line.moveSecondPoint(self.start_qub_p._x, self.start_qub_p._y)
+
+    def move(self, new_positions):
+        self.qub_line.moveFirstPoint(new_positions[0][0], new_positions[0][1])
+        self.qub_line.moveSecondPoint(new_positions[1][0], new_positions[1][1])
+
+    def highlight(self):
+	return
+
+    def unhighlight(self):
+	return
+
+    def get_hit(self, x, y):
+        return None
+        #return self.qub_line.getModifyClass(x, y)
+
+    def get_qub_objects(self):
+        return [self.start_qub_p, self.end_qub_p, self.qub_line]
+
+    def get_points_index(self):
+        if self.start_cpos and self.end_cpos:
+            return (self.start_cpos.get_index(), self.end_cpos.get_index())
+
+class Point(Shape):
+    def __init__(self, drawing, centred_position, screen_pos):
+        Shape.__init__(self)
+
+        self.qub_point = None
+
+        if centred_position is None:
+            self.centred_position = queue_model_objects.CentredPosition()
+            self.centred_position.centring_method = False
+        else:
+            self.centred_position = centred_position
+        self.screen_pos = screen_pos
+        self.point_index = None
+        self._drawing = drawing
+
+        self.qub_point = self.draw(screen_pos)
+
+    def set_index(self, index):
+        self.point_index = index
+
+    def get_index(self):
+        return self.point_index
+
+    def get_qub_point(self):
+        return self.qub_point
+
+    def get_centred_positions(self):
+        return [self.centred_position]
+
+    def draw(self, screen_pos):
+        """
+        Draws a qub point in the sample video.
+        """
+        qub_point = None
+
+        return qub_point
+
+    def show(self):
+        return
+
+    def hide(self):
+	return
+
+    def move(self, new_positions):
+	return
+
+    def highlight(self):
+	return
+
+    def unhighlight(self):
+	return
+

--- a/queue_entry.py
+++ b/queue_entry.py
@@ -26,7 +26,6 @@ import logging
 import time
 import queue_model_objects_v1 as queue_model_objects
 import os
-import ShapeHistory as shape_history
 import autoprocessing
 
 #import edna_test_data

--- a/queue_entry.py
+++ b/queue_entry.py
@@ -552,7 +552,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
             # Create a centred postions of the current postion
             pos_dict = self.diffractometer_hwobj.getPositions()
             cpos = queue_model_objects.CentredPosition(pos_dict)
-            pos = shape_history.Point(None, cpos, None) #, True)
+            #pos = shape_history.Point(None, cpos, None) #, True)
 
         # Get tasks associated with this centring
         tasks = self.get_data_model().get_tasks()

--- a/queue_entry.py
+++ b/queue_entry.py
@@ -557,7 +557,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
         # Get tasks associated with this centring
         tasks = self.get_data_model().get_tasks()
 
-        for task in tasks:
+        """for task in tasks:
             cpos = pos.get_centred_positions()[0]
 
             if pos.qub_point is not None:
@@ -567,7 +567,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
                 snapshot = self.shape_history.get_snapshot([])
 
             cpos.snapshot_image = snapshot 
-            task.set_centred_positions(cpos)
+            task.set_centred_positions(cpos)"""
 
         self.get_view().setText(1, 'Input accepted')
 

--- a/queue_model_objects_v1.py
+++ b/queue_model_objects_v1.py
@@ -1313,6 +1313,7 @@ def to_collect_dict(data_collection, session, sample, centred_pos=None):
              'lims_end_pos_id': data_collection.lims_end_pos_id,
              #'nb_sum_images': 0,
              'EDNA_files_dir': acquisition.path_template.process_directory,
+             'xds_dir': acquisition.path_template.xds_dir,
              'anomalous': proc_params.anomalous,
              #'file_exists': 0,
              'experiment_type': queue_model_enumerables.\


### PR DESCRIPTION
1. take a few mockups from the master, where some issues have been solved, e.x. EnergyMockup
2. improve some mockups with a few new methods
3. ShapeHistory contains a lot of UI, which should be moved to the brick. To minimize the change of queue_entry, a shapehistoryMockup is created for mxcube3 as a temp solution. 
4. remove "import ShapeHistory as shape_history" in queue_entry, to allow for mxcube3. Besides, it's not needed
5. In the return of to_collect_dict method in queue_model_objects_v1.py, add xds_dir for queue_entry. Sorry for pulling this one here, I know it's not mockup related... 
