### PR TITLE
Removed mesh comment which can become too long (> 1024 characters) for large meshes

### DIFF
--- a/ISPyBClient2.py
+++ b/ISPyBClient2.py
@@ -1572,14 +1572,6 @@ class ISPyBValueFactory():
 
                     if mesh_used:
                         mx_collect_dict['experiment_type'] = 'Mesh'
-                        comment = mx_collect_dict.get("comment", "")
-                        if not comment:
-                            try:
-                                mx_collect_dict['comment'] = \
-                                    'Mesh: phiz:' +  str(mx_collect_dict['motors'].values()[0]) + \
-                                    ', phiy' + str(mx_collect_dict['motors'].values()[1])
-                            except:
-                                mx_collect_dict['comment'] = 'Mesh: Unknown motor positions'
 
                 group.experimentType = mx_collect_dict['experiment_type']
             except KeyError,diag:


### PR DESCRIPTION
This error is reported by ISPyB for large meshes: 

WebFault: Server raised fault: 'java.lang.IllegalArgumentException: DataCollectionGroup: The 'comments' field is too long! max. char. 1024.'

If this PR is accepted I'll prepare PRs for master and 2.2 as well.
