### PR TITLE
Some ESRF-specific changes and added 'first_image_timeout' in AbstractMultiCollect.py

### DIFF
--- a/AbstractMultiCollect.py
+++ b/AbstractMultiCollect.py
@@ -56,6 +56,8 @@ class AbstractMultiCollect(object):
         self.oscillations_history = []
         self.current_lims_sample = None
         self.__safety_shutter_close_task = None
+        #wait for the 1st image from detector for 30 seconds by default
+        self.first_image_timeout = 30
 
 
     def setControlObjects(self, **control_objects):
@@ -628,6 +630,7 @@ class AbstractMultiCollect(object):
             return
 
 	# data collection
+        self.first_image_timeout = 30+oscillation_parameters["exposure_time"]
         self.data_collection_hook(data_collect_parameters)
 
         if 'transmission' in data_collect_parameters:
@@ -786,7 +789,7 @@ class AbstractMultiCollect(object):
                                                      data_collect_parameters.get("sample_reference", {}).get("cell", ""))
 
                       if data_collect_parameters.get("shutterless"):
-                          with gevent.Timeout(30, RuntimeError("Timeout waiting for detector trigger, no image taken")):
+                          with gevent.Timeout(self.first_image_timeout, RuntimeError("Timeout waiting for detector trigger, no image taken")):
    			      while self.last_image_saved() == 0:
                                   time.sleep(exptime)
                           

--- a/ESRF/ESRFMultiCollect.py
+++ b/ESRF/ESRFMultiCollect.py
@@ -474,6 +474,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
 
     @task
     def data_collection_cleanup(self):
+        self.stop_oscillation()
         self.close_fast_shutter()
 
 
@@ -546,7 +547,9 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
     
     def do_oscillation(self, start, end, exptime, npass):
         return self._detector.do_oscillation(start, end, exptime, npass)
-    
+   
+    def stop_oscillation(self):
+        pass 
   
     def start_acquisition(self, exptime, npass, first_frame):
         return self._detector.start_acquisition(exptime, npass, first_frame)

--- a/ESRF/ID30A3MultiCollect.py
+++ b/ESRF/ID30A3MultiCollect.py
@@ -108,6 +108,10 @@ class ID30A3MultiCollect(ESRFMultiCollect):
     def close_fast_shutter(self):
         self.getObjectByRole("diffractometer").controller.fshut.close()
 
+    def stop_oscillation(self):
+        self.getObjectByRole("diffractometer").controller.omega.stop()
+        self.getObjectByRole("diffractometer").controller.musst.putget("#ABORT")
+
     def set_helical(self, helical_on):
         self.helical = helical_on
 

--- a/ESRF/ID30A3MultiCollect.py
+++ b/ESRF/ID30A3MultiCollect.py
@@ -20,8 +20,11 @@ class ID30A3MultiCollect(ESRFMultiCollect):
     @task
     def data_collection_hook(self, data_collect_parameters):
       oscillation_parameters = data_collect_parameters["oscillation_sequence"][0]
-      if oscillation_parameters['range']/oscillation_parameters['exposure_time'] > 90:
+      exp_time = oscillation_parameters['exposure_time']
+      if oscillation_parameters['range']/exp_time > 90:
           raise RuntimeError("Cannot move omega axis too fast (limit set to 90 degrees per second).")
+
+      self.first_image_timeout = 30+exp_time*min(100, oscillation_parameters["number_of_images"])
  
       file_info = data_collect_parameters["fileinfo"]
       diagfile = os.path.join(file_info["directory"], file_info["prefix"])+"_%d_diag.dat" % file_info["run_number"]

--- a/ESRF/ID30A3MultiCollect.py
+++ b/ESRF/ID30A3MultiCollect.py
@@ -19,6 +19,9 @@ class ID30A3MultiCollect(ESRFMultiCollect):
 
     @task
     def data_collection_hook(self, data_collect_parameters):
+      ESRFMultiCollect.data_collection_hook(self, data_collect_parameters)
+      self._reset_detector_task = None
+
       oscillation_parameters = data_collect_parameters["oscillation_sequence"][0]
       exp_time = oscillation_parameters['exposure_time']
       if oscillation_parameters['range']/exp_time > 90:
@@ -112,6 +115,17 @@ class ID30A3MultiCollect(ESRFMultiCollect):
         self.getObjectByRole("diffractometer").controller.omega.stop()
         self.getObjectByRole("diffractometer").controller.musst.putget("#ABORT")
 
+    def reset_detector(self):
+        self.stop_oscillation()
+        self._reset_detector_task = ESRFMultiCollect.reset_detector(self, wait=False)
+
+    @task
+    def data_collection_cleanup(self):
+        self.stop_oscillation()
+        self.close_fast_shutter()
+        if self._reset_detector_task is not None:
+            self._reset_detector_task.get()
+ 
     def set_helical(self, helical_on):
         self.helical = helical_on
 

--- a/RobodiffFShut.py
+++ b/RobodiffFShut.py
@@ -31,7 +31,9 @@ class RobodiffFShut(Equipment):
 
     def wagoIn(self):
         self.robodiff.controller.fshut.open()
+        self.getWagoState(read=True)
            
     def wagoOut(self):  
         self.robodiff.controller.fshut.close()
+        self.getWagoState(read=True)
            

--- a/RobodiffFShut.py
+++ b/RobodiffFShut.py
@@ -8,7 +8,7 @@ class RobodiffFShut(Equipment):
 
     def init(self):
         self.robodiff = self.getObjectByRole("robot")
-        self.connect(self.robodiff.controller.fshut, "status", self.valueChanged)
+        self.connect(self.robodiff.controller.fshut, "state", self.valueChanged)
         self.wagoState = "unknown"
 
     def connectNotify(self, signal):
@@ -26,7 +26,7 @@ class RobodiffFShut(Equipment):
         
     def getWagoState(self, read=False):
         if read:
-          self.valueChanged(self.robodiff.controller.fshut.status())
+          self.valueChanged(self.robodiff.controller.fshut.state())
         return self.wagoState 
 
     def wagoIn(self):


### PR DESCRIPTION
This PR adds a kind of new feature: it sets a configurable timeout to wait for the
first image to appear on disk (previously in 2.1 branch it was hard-coded to
30 seconds).

This helps fixing a bug on ID30A3 with the Eiger detector: since the first frames
are written by bunches of N images, it can take a while for the file to be written,
and thus we can adapt now this timeout.

Apart from that, the changes are only specific to ESRF files.
