### PR TITLE
#200+#204 , for master

### DIFF
--- a/ESRF/ESRFMetadataManagerClient.py
+++ b/ESRF/ESRFMetadataManagerClient.py
@@ -153,8 +153,7 @@ class MXCuBEMetadataClient(object):
         self._sessionObject = self.esrf_multi_collect.getObjectByRole("session")
 
         self._beamline = self._sessionObject.endstation_name
-
-
+    
     def reportStackTrace(self):
         (exc_type, exc_value, exc_traceback) = sys.exc_info()
         errorMessage = "{0} {1}".format(exc_type, exc_value)
@@ -205,7 +204,6 @@ class MXCuBEMetadataClient(object):
                 prefix = fileinfo["prefix"]
                 run_number = int(fileinfo["run_number"])
                 # Connect to ICAT metadata database
-
                 # Strip the prefix from any workflow expTypePrefix
                 # TODO: use the ISPyB sample name instead
                 sampleName = prefix
@@ -253,7 +251,6 @@ class MXCuBEMetadataClient(object):
                 image_no = index + start_image_number
                 image_path = os.path.join(directory, template % image_no)
                 self._metadataManagerClient.appendFile(image_path)
-
 
     def end(self, data_collect_parameters):
         try:

--- a/ESRF/ESRFMultiCollect.py
+++ b/ESRF/ESRFMultiCollect.py
@@ -62,14 +62,14 @@ class CcdDetector:
           self._detector.init(config, collect_obj)
 
     @task
-    def prepare_acquisition(self, take_dark, start, osc_range, exptime, npass, number_of_images, comment="", energy=None):
+    def prepare_acquisition(self, take_dark, start, osc_range, exptime, npass, number_of_images, comment="", energy=None, gate = False):
         if osc_range < 1E-4:
             still = True
         else:
             still = False
         
         if self._detector:
-            self._detector.prepare_acquisition(take_dark, start, osc_range, exptime, npass, number_of_images, comment, energy, still)
+            self._detector.prepare_acquisition(take_dark, start, osc_range, exptime, npass, number_of_images, comment, energy, still, gate)
         else:
             self.getChannelObject("take_dark").setValue(take_dark)
             self.execute_command("prepare_acquisition", take_dark, start, osc_range, exptime, npass, comment)
@@ -159,9 +159,12 @@ class PixelDetector:
 
     def last_image_saved(self):
         return self._detector.last_image_saved()
+        
+    def get_deadtime(self):
+        return self._detector.get_deadtime()
 
     @task
-    def prepare_acquisition(self, take_dark, start, osc_range, exptime, npass, number_of_images, comment="", energy=None):
+    def prepare_acquisition(self, take_dark, start, osc_range, exptime, npass, number_of_images, comment="", energy=None, gate = False):
         self.new_acquisition = True
         if osc_range < 1E-4:
             still = True
@@ -172,7 +175,7 @@ class PixelDetector:
             self.shutterless_range = osc_range*number_of_images
             self.shutterless_exptime = (exptime + self._detector.get_deadtime())*number_of_images
         if self._detector:
-            self._detector.prepare_acquisition(take_dark, start, osc_range, exptime, npass, number_of_images, comment, energy, still)
+            self._detector.prepare_acquisition(take_dark, start, osc_range, exptime, npass, number_of_images, comment, energy, still, gate)
         else:
             self.execute_command("prepare_acquisition", take_dark, start, osc_range, exptime, npass, comment)
         
@@ -341,7 +344,6 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
     @task
     def data_collection_end_hook(self, data_collect_parameters):
         self._metadataClient.end(data_collect_parameters)
-
 
     def do_prepare_oscillation(self, start, end, exptime, npass):
         return self.execute_command("prepare_oscillation", start, end, exptime, npass)
@@ -532,7 +534,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
         os.chmod(hkl_file_path, 0666)
 
         for input_file_dir, file_prefix in ((self.raw_data_input_file_dir, "../.."), (self.xds_directory, "../links")): 
-	    xds_input_file = os.path.join(input_file_dir, "XDS.INP")
+            xds_input_file = os.path.join(input_file_dir, "XDS.INP")
             conn.request("GET", "/xds.inp/%d?basedir=%s" % (collection_id, file_prefix))
             xds_file = open(xds_input_file, "w")
             r = conn.getresponse()

--- a/ESRF/ID30A1PhotonFlux.py
+++ b/ESRF/ID30A1PhotonFlux.py
@@ -14,6 +14,7 @@ class ID30A1PhotonFlux(Equipment):
         self.musst = controller.musst
         self.energy_motor = self.getDeviceByRole("energy")
         self.shutter = self.getDeviceByRole("shutter")
+        self.aperture = self.getObjectByRole("aperture")
         self.factor = self.getProperty("current_photons_factor")
 
         self.shutter.connect("shutterStateChanged", self.shutterStateChanged)
@@ -38,6 +39,15 @@ class ID30A1PhotonFlux(Equipment):
         """
         self.tg_device.MeasureSingle()
         counts = abs(self.tg_device.ReadData)*1E6
+        if self.aperture:
+            try:
+                aperture_coef = self.aperture.getApertureCoef()
+            except Exception:
+                aperture_coef = 1
+        else:
+            aperture_coef = 1
+
+        counts *= aperture_coef
         return counts
 
     def connectNotify(self, signal):
@@ -61,9 +71,9 @@ class ID30A1PhotonFlux(Equipment):
         return self.current_flux
 
     def emitValueChanged(self, flux=None):
+        self.current_flux = flux
+
         if flux is None:
-          self.current_flux = None
-          self.emit("valueChanged", ("?", ))
+            self.emit("valueChanged", ("?", ))
         else:
-          self.current_flux = flux
-          self.emit("valueChanged", (self.current_flux, ))
+            self.emit("valueChanged", (self.current_flux, ))

--- a/detectors/LimaEiger.py
+++ b/detectors/LimaEiger.py
@@ -62,7 +62,7 @@ class Eiger:
       return float(self.config.getProperty("deadtime"))
 
   @task
-  def prepare_acquisition(self, take_dark, start, osc_range, exptime, npass, number_of_images, comment, energy, still):
+  def prepare_acquisition(self, take_dark, start, osc_range, exptime, npass, number_of_images, comment, energy, still, gate=False):
       diffractometer_positions = self.collect_obj.bl_control.diffractometer.getPositions()
       self.start_angles = list()
       for i in range(number_of_images):
@@ -110,10 +110,14 @@ class Eiger:
  
       self.set_energy_threshold(energy)
 
-      if still:
-          self.getChannelObject("acq_trigger_mode").setValue("INTERNAL_TRIGGER")
-      else:
-          self.getChannelObject("acq_trigger_mode").setValue("EXTERNAL_TRIGGER")
+      if gate:
+          self.getChannelObject("acq_trigger_mode").setValue("EXTERNAL_GATE")
+      else :
+          if still:
+              self.getChannelObject("acq_trigger_mode").setValue("INTERNAL_TRIGGER")
+          else:
+              self.getChannelObject("acq_trigger_mode").setValue("EXTERNAL_TRIGGER")
+
 
       self.getChannelObject("saving_frame_per_file").setValue(min(100,number_of_images))
       self.getChannelObject("saving_mode").setValue("AUTO_FRAME")

--- a/queue_model_objects_v1.py
+++ b/queue_model_objects_v1.py
@@ -606,10 +606,9 @@ class DataCollection(TaskNode):
                 display_name = "%s (Line %d:%d)" %(self.get_name(), start_index, end_index)
             else:
                 display_name = self.get_name()
-        elif self.is_mesh():
-            lines, images_per_line = self.grid.get_line_image_per_line_num()
-            display_name = "%s (Mesh %d - %d x %d)" % (self.get_name(), 
-                  self.grid.index + 1, lines, images_per_line)
+        elif self.experiment_type == queue_model_enumerables.EXPERIMENT_TYPE.MESH:
+            #display_name = "%s (%s)" %(self.get_name(), self.grid_id)
+            display_name = "%s" %(self.get_name())
         else:
             index = self.get_point_index()
             if index:


### PR DESCRIPTION
bug fix: do not try to move kappa motors if kappa is not enabled (missing minikappa on MD2 for example),
this relies on having a ' in_kappa_mode' method as a member of the diffractometer object...
removed old, unused code
Some changes in ESRF-specific files
queue_entry: call set_mesh_scan_parameters instead of setMeshScanParameters, use set_mesh
queue_model_objects_v1: changed display name for mesh