### PR TITLE
[2.2] - Missing set_mesh

### DIFF
--- a/AbstractCollect.py
+++ b/AbstractCollect.py
@@ -78,6 +78,11 @@ class AbstractCollect(object):
         self.sample_changer_hwobj = None
         self.transmission_hwobj = None
 
+        self.mesh = None
+        self.mesh_num_lines = None
+        self.mesh_total_nb_frames = None
+        self.mesh_range = None
+        self.mesh_center = None
         self.ready_event = gevent.event.Event()
 
     def set_beamline_configuration(self, **configuration_parameters):
@@ -644,3 +649,22 @@ class AbstractCollect(object):
         Descript. : 
         """
         pass
+
+
+    # specifies the next scan will be a mesh scan
+    def set_mesh(self, mesh_on):
+        self.mesh = mesh_on
+
+    def set_mesh_scan_parameters(self, num_lines, total_nb_frames, mesh_center_param, mesh_range_param):
+        """
+        sets the mesh scan parameters :
+         - vertcal range
+         - horizontal range
+         - nb lines
+         - nb frames per line
+         - invert direction (boolean)  # NOT YET DONE
+         """
+        self.mesh_num_lines = num_lines
+        self.mesh_total_nb_frames = total_nb_frames
+        self.mesh_range = mesh_range_param
+        self.mesh_center = mesh_center_param

--- a/AbstractMultiCollect.py
+++ b/AbstractMultiCollect.py
@@ -61,6 +61,11 @@ class AbstractMultiCollect(object):
         #wait for the 1st image from detector for 30 seconds by default
         self.first_image_timeout = 30
 
+        self.mesh = None
+        self.mesh_num_lines = None
+        self.mesh_total_nb_frames = None
+        self.mesh_range = None
+        self.mesh_center = None
 
     def setControlObjects(self, **control_objects):
       self.bl_control = BeamlineControl(**control_objects)
@@ -983,4 +988,22 @@ class AbstractMultiCollect(object):
               autoprocessing.startInducedRadDam(processAnalyseParams)
             except:
               logging.exception("Error starting induced rad.dam")
+
+    # specifies the next scan will be a mesh scan
+    def set_mesh(self, mesh_on):
+        self.mesh = mesh_on
+
+    def set_mesh_scan_parameters(self, num_lines, total_nb_frames, mesh_center_param, mesh_range_param):
+        """
+        sets the mesh scan parameters :
+         - vertcal range
+         - horizontal range
+         - nb lines
+         - nb frames per line
+         - invert direction (boolean)  # NOT YET DONE
+         """
+        self.mesh_num_lines = num_lines
+        self.mesh_total_nb_frames = total_nb_frames
+        self.mesh_range = mesh_range_param
+        self.mesh_center = mesh_center_param
                

--- a/ESRF/ID30A3MultiCollect.py
+++ b/ESRF/ID30A3MultiCollect.py
@@ -166,34 +166,12 @@ class ID30A3MultiCollect(ESRFMultiCollect):
 
         if self._reset_detector_task is not None:
             self._reset_detector_task.get()
- 
+
     def set_helical(self, helical_on):
         self.helical = helical_on
 
     def set_helical_pos(self, helical_oscil_pos):
         self.helical_pos = helical_oscil_pos
-        
-    # specifies the next scan will be a mesh scan
-    def set_mesh(self, mesh_on):
-        self.mesh = mesh_on
-
-    def set_mesh_scan_parameters(self, num_lines, total_nb_frames, mesh_center_param, mesh_range_param):
-        """
-        sets the mesh scan parameters :
-         - vertcal range
-         - horizontal range
-         - nb lines
-         - nb frames per line
-         - invert direction (boolean)  # NOT YET DONE
-         """
-        self.mesh_num_lines = num_lines
-        self.mesh_total_nb_frames = total_nb_frames
-        self.mesh_range = mesh_range_param
-        self.mesh_center = mesh_center_param
-
-        
-        
-        
 
     def set_transmission(self, transmission):
         self.getObjectByRole("transmission").set_value(transmission)

--- a/MultiCollectMockup.py
+++ b/MultiCollectMockup.py
@@ -304,3 +304,7 @@ class MultiCollectMockup(AbstractMultiCollect, HardwareObject):
     @task
     def generate_image_jpeg(self, filename, jpeg_path, jpeg_thumbnail_path):
         pass
+    
+    def set_mesh(self, flag):
+        return
+

--- a/MultiCollectMockup.py
+++ b/MultiCollectMockup.py
@@ -304,7 +304,3 @@ class MultiCollectMockup(AbstractMultiCollect, HardwareObject):
     @task
     def generate_image_jpeg(self, filename, jpeg_path, jpeg_thumbnail_path):
         pass
-    
-    def set_mesh(self, flag):
-        return
-


### PR DESCRIPTION
It looks like someone added set_mesh to DataCollectionQueueEntry a while a go and did not add the corresponding definition to MultiCollectMockup

So here you go !.

Marcus