### PR TITLE
Issue #215: Added new methods to the XMLRPCServer

### DIFF
--- a/Microdiff.py
+++ b/Microdiff.py
@@ -48,15 +48,9 @@ class Microdiff(MiniDiff.MiniDiff):
         self.centringPhiy.direction = -1
         self.MOTOR_TO_EXPORTER_NAME = self.getMotorToExporterNames()
 
-    def getMotorToExporterNames(self):
-        #only temporary. Get the names from the xml files
-        MOTOR_TO_EXPORTER_NAME = {"focus":"AlignmentX", "kappa":"Kappa",
-                                  "kappa_phi":"Phi", "phi": "Omega",
-                                  "phiy":"AlignmentY", "phiz":"AlignmentZ",
-                                  "sampx":"CentringX", "sampy":"CentringY",
-                                  "zoom":"Zoom"}
-        return MOTOR_TO_EXPORTER_NAME
-
+        self.frontLight = self.getDeviceByRole('flight')
+        self.backLight = self.getDeviceByRole('light')  
+        self.beam_info = self.getObjectByRole('beam_info')
 
     def getMotorToExporterNames(self):
         #only temporary. Get the names from the xml files
@@ -267,6 +261,18 @@ class Microdiff(MiniDiff.MiniDiff):
                                                                   self.getBeamPosX(), self.getBeamPosY())
                                                                          
         self.currentCentringProcedure.link(self.manualCentringDone)
+
+    def getFrontLightLevel(self):
+        return self.frontLight.getPosition()
+
+    def setFrontLightLevel(self, level):
+        return self.frontLight.move(level)
+
+    def getBackLightLevel(self):
+        return self.backLight.getPosition()
+
+    def setBackLightLevel(self, level):
+        return self.backLight.move(level)
 
 def set_light_in(light, light_motor, zoom):
     MICRODIFF.getDeviceByRole("flight").move(0)

--- a/XMLRPCServer.py
+++ b/XMLRPCServer.py
@@ -112,6 +112,13 @@ class XMLRPCServer(HardwareObject):
         self._server.register_function(self.dozor_status_changed)
         self.image_num = 0
         self._server.register_function(self.get_image_num, "get_image_num")
+        self._server.register_function(self.set_zoom_level) 
+        self._server.register_function(self.get_zoom_level) 
+        self._server.register_function(self.get_available_zoom_levels) 
+        self._server.register_function(self.set_front_light_level) 
+        self._server.register_function(self.get_front_light_level) 
+        self._server.register_function(self.set_back_light_level) 
+        self._server.register_function(self.get_back_light_level) 
 
         # Register functions from modules specified in <apis> element
         if self.hasObject("apis"):
@@ -386,14 +393,11 @@ class XMLRPCServer(HardwareObject):
         return True
 
     def get_aperture(self):
-        return self.diffractometer_hwobj.beam_info.aperture_hwobj.getPosition()
+        return self.diffractometer_hwobj.beam_info.aperture_hwobj.getCurrentPositionName()
 
     def get_aperture_list(self):
-        aperture_list=[]
-        for i in range(0, len(self.diffractometer_hwobj.beam_info.aperture_hwobj['positions'])):
-            aperture_list.append(self.diffractometer_hwobj.beam_info.aperture_hwobj['positions'][0][i].getProperty('name'))
-        return aperture_list
-    
+        return self.diffractometer_hwobj.beam_info.aperture_hwobj.getPredefinedPositionsList()
+
     def open_dialog(self, dict_dialog):
         """
         Opens the workflow dialog in mxCuBE.
@@ -424,6 +428,53 @@ class XMLRPCServer(HardwareObject):
     def get_image_num(self):
         return self.image_num
   
+    def set_zoom_level(self, zoom_level):
+        """
+        Sets the zoom to a pre-defined level.
+        """
+        self.diffractometer_hwobj.zoomMotor.moveToPosition(zoom_level)
+
+    def get_zoom_level(self):
+        """
+        Returns the zoom level.
+        """
+        return self.diffractometer_hwobj.zoomMotor.getCurrentPositionName()
+
+    def get_available_zoom_levels(self):
+        """
+        Returns the avaliable pre-defined zoom levels.
+        """
+        return self.diffractometer_hwobj.zoomMotor.getPredefinedPositionsList()
+
+    def set_zoom_level(self, zoom_level):
+        """
+        Sets the zoom to a pre-defined level.
+        """
+        self.diffractometer_hwobj.zoomMotor.moveToPosition(zoom_level)
+
+    def set_front_light_level(self, level):
+        """
+        Sets the level of the front light
+        """
+        self.diffractometer_hwobj.setFrontLightLevel(level)
+
+    def get_front_light_level(self):
+        """
+        Gets the level of the front light
+        """
+        return self.diffractometer_hwobj.getFrontLightLevel()
+
+    def set_back_light_level(self, level):
+        """
+        Sets the level of the back light
+        """
+        self.diffractometer_hwobj.setBackLightLevel(level)
+
+    def get_back_light_level(self):
+        """
+        Gets the level of the back light
+        """
+        return self.diffractometer_hwobj.getBackLightLevel()
 
     def _register_module_functions(self, module_name, recurse=True, prefix=""):
         log = logging.getLogger("HWR")


### PR DESCRIPTION
- The 'getMotorToExporterNames' was deleted because it was duplicated in the original revision
- The XMLRPCServer aperture methods have been simplified

I have tested these changes on ID30b.