### PR TITLE
disable model&entry in post-execute

### DIFF
--- a/queue_entry.py
+++ b/queue_entry.py
@@ -316,6 +316,8 @@ class BaseQueueEntry(QueueEntryContainer):
         view.setOn(False)
         self.get_data_model().set_executed(True)
         self.get_data_model().set_running(False)
+        self.get_data_model().set_enabled(False)
+        self.set_enabled(False)
         self._set_background_color()
 
     def _set_background_color(self):


### PR DESCRIPTION
I noticed that I if I run the queue with failed tasks they will be run again. This fix prevents that.

If you are ok with this, I will do pr to 2.2.

mikel