### PR TITLE
[Master] 2017.05.19. Set precision with static method

### DIFF
--- a/BeamlineSetup.py
+++ b/BeamlineSetup.py
@@ -354,12 +354,14 @@ class BeamlineSetup(HardwareObject):
         path_template.run_number = self[parent_key].getProperty('run_number')
         path_template.suffix = self.session_hwobj["file_info"].getProperty('file_suffix')
 
+        """
         path_template.precision = '04'
         try:
            if self.session_hwobj["file_info"].getProperty('precision'):
                path_template.precision = eval(self.session_hwobj["file_info"].getProperty('precision'))
         except:
            pass
+        """
         
         path_template.start_num = int(self[parent_key].getProperty('start_image_number'))
         path_template.num_files = int(self[parent_key].getProperty('number_of_images'))

--- a/Session.py
+++ b/Session.py
@@ -66,6 +66,14 @@ class Session(HardwareObject):
            self['file_info'].getProperty('archive_base_directory'),
            self['file_info'].getProperty('archive_folder'))
 
+        precision = "04"
+        try:
+            precision = eval(self.session_hwobj["file_info"].getProperty('precision'))
+        except:
+            pass
+
+        queue_model_objects.PathTemplate.set_precision(precision)
+
     def get_base_data_directory(self):
         """
         Returns the base data directory taking the 'contextual'

--- a/queue_model_objects_v1.py
+++ b/queue_model_objects_v1.py
@@ -197,7 +197,7 @@ class TaskGroup(TaskNode):
 
     def set_name_from_task(self, task):
         if isinstance(task, DataCollection):
-            self._name = "Standart"
+            self._name = "Standard"
 
 class Sample(TaskNode):
     def __init__(self):

--- a/queue_model_objects_v1.py
+++ b/queue_model_objects_v1.py
@@ -195,6 +195,10 @@ class TaskGroup(TaskNode):
         self.lims_group_id = None
         self.interleave_num_images = None
 
+    def set_name_from_task(self, task):
+        if isinstance(task, DataCollection):
+            self._name = "Standart"
+
 class Sample(TaskNode):
     def __init__(self):
         TaskNode.__init__(self)
@@ -1117,6 +1121,10 @@ class PathTemplate(object):
         PathTemplate.synchotron_name = synchotron_name
         PathTemplate.template = template
 
+    @staticmethod
+    def set_precision(precision):
+        PathTemplate.precision = precision
+
     def __init__(self):
         object.__init__(self)
 
@@ -1129,7 +1137,7 @@ class PathTemplate(object):
         self.wedge_prefix = str()
         self.run_number = int()
         self.suffix = str()
-        self.precision = str()
+        #self.precision = str()
         self.start_num = int()
         self.num_files = int()
 


### PR DESCRIPTION
* Set file precision via static method. This needed if queue is populated not directly via queue manager. For example loaded from file.